### PR TITLE
Update VPM manifest for mono-ui v0.0.0

### DIFF
--- a/public/vpm.json
+++ b/public/vpm.json
@@ -3,5 +3,30 @@
   "id": "dev.limitex",
   "url": "https://docs.limitex.dev/vpm.json",
   "author": "Limitex",
-  "packages": {}
+  "packages": {
+    "dev.limitex.mono-ui": {
+      "versions": {
+        "0.0.0": {
+          "name": "dev.limitex.mono-ui",
+          "version": "0.0.0",
+          "displayName": "Mono UI",
+          "description": "This is an package",
+          "unity": "2022.3",
+          "unityRelease": "22f1",
+          "dependencies": {},
+          "keywords": [],
+          "author": {
+            "name": "Limitex",
+            "email": "76650151+Limitex@users.noreply.github.com",
+            "url": "https://github.com/Limitex/mono-ui"
+          },
+          "vpmDependencies": {
+            "com.vrchat.worlds": "3.7.3"
+          },
+          "url": "https://github.com/Limitex/mono-ui",
+          "license": "MIT"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR updates the VPM manifest to include the new release of mono-ui v0.0.0.

- Added new version to VPM manifest
- Release: https://github.com/Limitex/mono-ui/releases/tag/v0.0.0