### PR TITLE
Update VPM manifest for mono-ui v0.0.0-b.1

### DIFF
--- a/public/vpm.json
+++ b/public/vpm.json
@@ -6,6 +6,28 @@
   "packages": {
     "dev.limitex.mono-ui": {
       "versions": {
+        "0.0.0-b.1": {
+          "name": "dev.limitex.mono-ui",
+          "version": "0.0.0-b.1",
+          "displayName": "Mono UI",
+          "description": "This is an package",
+          "unity": "2022.3",
+          "unityRelease": "22f1",
+          "dependencies": {
+            "com.unity.textmeshpro": "3.0.6"
+          },
+          "keywords": [],
+          "author": {
+            "name": "Limitex",
+            "email": "76650151+Limitex@users.noreply.github.com",
+            "url": "https://github.com/Limitex/mono-ui"
+          },
+          "vpmDependencies": {
+            "com.vrchat.worlds": ">=3.7.0"
+          },
+          "url": "https://github.com/Limitex/mono-ui/releases/download/v0.0.0-b.1/mono-ui-0.0.0-b.1.zip",
+          "license": "MIT"
+        },
         "0.0.0-a.4": {
           "name": "dev.limitex.mono-ui",
           "version": "0.0.0-a.4",


### PR DESCRIPTION
This PR updates the VPM manifest to include the new release of mono-ui v0.0.0-b.1.

- Added new version to VPM manifest
- Release: https://github.com/Limitex/mono-ui/releases/tag/v0.0.0-b.1