### PR TITLE
Update VPM manifest for mono-ui v1.0.0-rc.1

### DIFF
--- a/public/vpm.json
+++ b/public/vpm.json
@@ -6,6 +6,32 @@
   "packages": {
     "dev.limitex.mono-ui": {
       "versions": {
+        "1.0.0-rc.1": {
+          "name": "dev.limitex.mono-ui",
+          "version": "1.0.0-rc.1",
+          "displayName": "Mono UI",
+          "description": "Mono UI is a UI component package for VRChat world creation. It provides simple and customizable UI elements optimized for VRChat environments, helping creators build interactive and user-friendly interfaces in their worlds.",
+          "unity": "2022.3",
+          "unityRelease": "22f1",
+          "dependencies": {
+            "com.unity.textmeshpro": "3.0.6",
+            "com.vrchat.base": "3.7.0",
+            "com.vrchat.worlds": "3.7.0"
+          },
+          "keywords": [],
+          "author": {
+            "name": "Limitex",
+            "email": "76650151+Limitex@users.noreply.github.com",
+            "url": "https://github.com/Limitex/mono-ui"
+          },
+          "documentationUrl": "https://docs.limitex.dev/vrc/monoui",
+          "vpmDependencies": {
+            "com.vrchat.base": ">=3.7.0",
+            "com.vrchat.worlds": ">=3.7.0"
+          },
+          "url": "https://github.com/Limitex/mono-ui/releases/download/v1.0.0-rc.1/mono-ui-1.0.0-rc.1.zip",
+          "license": "MIT"
+        },
         "0.0.0-b.3": {
           "name": "dev.limitex.mono-ui",
           "version": "0.0.0-b.3",


### PR DESCRIPTION
This PR updates the VPM manifest to include the new release of mono-ui v1.0.0-rc.1.

- Added new version to VPM manifest
- Release: https://github.com/Limitex/mono-ui/releases/tag/v1.0.0-rc.1