### PR TITLE
docs: add warning callout for RC-only package availability

### DIFF
--- a/src/pages/vrc/monoui/installation.mdx
+++ b/src/pages/vrc/monoui/installation.mdx
@@ -6,6 +6,10 @@ import VPMRepositoryLink from "../../../components/vpm-repository-link.tsx";
 
 Learn how to install packages using the VRChat Creator Companion (VCC).
 
+<Callout type="warning">
+  Currently, only release candidate versions (-rc.*) are available. Please refer to the [#Installing Pre-release Versions](#installing-pre-release-versions) section below to access these versions.
+</Callout>
+
 <Steps>
 
 ## Add Repository


### PR DESCRIPTION
Add warning callout to highlight that only release candidate versions are currently available